### PR TITLE
[Redaktionella ändringar] Sektionskock -> preferensmästare fix

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -60,7 +60,6 @@
 \maketitle
 
 %%%%%%%%%%%%% SECTION %%%%%%%%%%%%%
-
 \section{Teknologia}
 
 \begin{reglemlista}
@@ -77,10 +76,6 @@
     Med Råsa Digitalis menas en råsa fingerborgsblomma, på latin Digitalis Purpurea.
 
 \end{reglemlista}
-
-
-
-
 
 %%%%%%%%%%%%% SECTION %%%%%%%%%%%%%
 \section{Hedersomnämnande}
@@ -99,12 +94,12 @@
 	\emph{Invald VTM 2010 för sina insatser som studievägledare för C- och D-programmet.}
 	\item Mats Cedervall \\
 	\emph{Invald på HTM1 2018 för sitt stora Intresse i sektionens lokaler och för att han som Husprefekt alltid har verkat för studenternas ökade inflytande i husstyrelsen}
-	
+
     \end{itemize}
 
   \item[Grundarna av Datatekniksektionen inom TLTH]
    Grundarna av Datatekniksektionen inom TLTH är:
-   
+
   \begin{itemize}
 	\item Lars Svensson
 	\item Ulf Bengtsson
@@ -133,7 +128,7 @@
   \item[Vårterminsmöte]
     Under vårterminsmötet skall följande poster tillsättas:
     \begin{itemize}
-    
+
       \item Karnevalsansvarig (väljs året innan karnevalen äger rum)
       \item Teknikfokusansvarig
       \item Medlem i Projektgruppen för Teknikfokus
@@ -185,8 +180,8 @@
       \item Medaljelelekommittémedlem
       \item Utedischoansvarig
       \item Alumniansvarig
-      
- 
+
+
     \end{itemize}
 
 \end{reglemlista}
@@ -232,7 +227,7 @@
           	\item D'du-redaktör
           	\item DJ
           	\item DWWW-ansvarig
-         	\item Her Tech Future representant 
+         	\item Her Tech Future representant
           	\item Fotograf
 	\item Kårrepresentant
           	\item Märkvärdig
@@ -252,10 +247,10 @@
           \item Sparkyansvarig
         \end{itemize}
     \end{attlista}
-    
+
     \item[Sammanträde]
     	Sektionsstyrelsen sammanträder på kallelse av ordförande eller vid dennes frånvaro av vice ordförande. Ständigt adjungerad är, förutom de av stadgan och reglementet fastställda, även E-sektionens ordförande och två styrelseledarmöter från D-chip.
-    
+
 
 \end{reglemlista}
 
@@ -287,7 +282,7 @@
       \item hålla styrelsen informerad om utskottets verksamhet
       \item utse erforderligt antal funktionärer utöver de av sektionen valda
     \end{attlista}
-	
+
 	\item[Titulering]
 	Alternativ titulering för utskottsordförande är mästare.
 
@@ -319,7 +314,7 @@
       \item erforderligt antal funktionärer
     \end{itemize}
 
-  
+
 
 \end{reglemlista}
 
@@ -353,7 +348,7 @@
     \end{itemize}
 
   \item[\textbf{Alumnigruppen}]
-  	
+
   	\item[Åligganden]
 		Det åligger alumnigruppen
 		\begin{attlista}
@@ -361,7 +356,7 @@
 			\item upprätthålla kontakten med utexaminerade D- och C-teknologer
 			\item underhålla examensmonumentet
   		\end{attlista}
-  	
+
 	\item[Sammansättning]
 		Alumnigruppen består av
 		\begin{itemize}
@@ -369,14 +364,14 @@
 			\item Alumnigruppsmedlem (erfoderligt antal)
 			\item Alumnimiddagsansvarig
 		\end{itemize}
-	
+
 
 \end{reglemlista}
 \textbf{Projektgruppen för Teknikfokus}
 \begin{reglemlista}
 	\item[Åligganden]
 	Det åligger Projektgruppen för Teknikfokus
-	
+
 	\begin{attlista}
 		\item på våren anordna arbetsmarknadsmässan Teknikfokus
 	\end{attlista}
@@ -431,16 +426,16 @@
       \item Sektionslivskvalitetsförhöjare
       \item erforderligt antal funktionärer
     \end{itemize}
-   
+
   \item[\textbf{Rootmästeriet}]
-  	
+
   	\item[Åligganden]
   		Det åligger Rootmästeriet
   		\begin{attlista}
   			\item underhålla och förbättra sektionens datorer, dess tillhörande utrustning, programvara och funktioner
   			\item under ledning av Sparkyansvarig underhålla och förbättra Sparky
   		\end{attlista}
-  	
+
 	\item[Sammansättning]
 		Rootmästeriet består av
 		\begin{itemize}
@@ -448,7 +443,7 @@
 			\item sudo
 			\item Sparkyansvarig
 		\end{itemize}
-	
+
 \end{reglemlista}
 
 %%%%%%%%%%%%% SECTION %%%%%%%%%%%%%
@@ -487,7 +482,7 @@ Medaljelelekommittén delar ut medaljer till sektionsfunktionärer. Medaljelelek
     \begin{attlista}
       \item anordna för sektionens medlemmar trevliga evenemang
       \item deltaga i sångarstriden
-      \item verka för att sektionen har lag med i av andra studentorganisationer anordnade aktiviteter, såsom Tandemstafetten och DÖMD 
+      \item verka för att sektionen har lag med i av andra studentorganisationer anordnade aktiviteter, såsom Tandemstafetten och DÖMD
       \item informera om större arrangemang på andra orter
     \end{attlista}
 
@@ -506,8 +501,8 @@ Medaljelelekommittén delar ut medaljer till sektionsfunktionärer. Medaljelelek
       \item D-shopen
       \item erforderligt antal funktionärer
     \end{itemize}
-    
-    
+
+
   \item[\textbf{D-shopen}]
 
     \item[Åligganden]
@@ -540,7 +535,7 @@ Medaljelelekommittén delar ut medaljer till sektionsfunktionärer. Medaljelelek
       \item dela ut publikationer från sektionen och TLTH såsom D'du, Litet Ordo och Pålsjö Ängsblad
       \item ansvara för sektionens WWW-sidor och att informationen på dessa hålls uppdaterad
     \end{attlista}
-    
+
      \item[Sammansättning]
     Informationsutskottet består av
     \begin{itemize}
@@ -558,22 +553,22 @@ Medaljelelekommittén delar ut medaljer till sektionsfunktionärer. Medaljelelek
 
   \item[D'du]
     D'du är sektionens informationsblad.
-    
+
     \item[\textbf{DWWW}]
-    
+
     \item[Åligganden]
     Det åligger DWWW
     	\begin{attlista}
 		\item underhålla och utveckla sektionens WWW-sidor
 	\end{attlista}
-	
+
     \item[Sammansättning]
     DWWW består av
     	\begin{itemize}
 		\item DWWW-ansvarig
 		\item DWWW-medlem (erforderligt antal)
 	\end{itemize}
-		
+
 
 \end{reglemlista}
 
@@ -637,7 +632,7 @@ Medaljelelekommittén delar ut medaljer till sektionsfunktionärer. Medaljelelek
     \begin{itemize}
       \item Skattmästare
       \item Vice Skattmästare
-      \item Erforderligt antal funktionärer 
+      \item Erforderligt antal funktionärer
     \end{itemize}
 
 \end{reglemlista}
@@ -666,7 +661,7 @@ Medaljelelekommittén delar ut medaljer till sektionsfunktionärer. Medaljelelek
       \item Peppare (erforderligt antal)
       \item Nollningsfunktionärer (erforderligt antal)
     \end{itemize}
-    
+
    \item[Staben]
     Staben består av
     \begin{itemize}
@@ -708,7 +703,7 @@ Medaljelelekommittén delar ut medaljer till sektionsfunktionärer. Medaljelelek
             \item Årskursrepresentant, D3
             \item Årskursrepresentant, C3
 
-            
+
 	\item erforderligt antal funktionärer
         \end{itemize}
       \item föreslå representanter till TLTH:s externa organ
@@ -743,7 +738,7 @@ Medaljelelekommittén delar ut medaljer till sektionsfunktionärer. Medaljelelek
       \item rapportera inkomna händelser till styrelsen
       \item stötta sektionsmedlemmar som har utsatts för kränkande behandling
       \end{attlista}
-      \item[Sammansättning] 
+      \item[Sammansättning]
       Trivselrådet består av
         \begin{itemize}
           	\item Vice Ordförande
@@ -752,7 +747,7 @@ Medaljelelekommittén delar ut medaljer till sektionsfunktionärer. Medaljelelek
           	\item Världsmästare
           	\item Her Tech Future representant
         \end{itemize}
-    
+
 
 \end{reglemlista}
 
@@ -981,11 +976,11 @@ Cafémästaren är ansvarig för sektionens caféverksamhet. Cafémästaren lede
 		\item vara kontaktperson för fria föreningar och eventuella projekt
 		\item anslå kallelser till styrelse- och sektionsmöten
 		\item föra protokoll vid styrelsemöten och sektionsmöten samt anslå dessa
-		\item arkivera uppförda protokoll och övriga handlingar i därför avsedd pärm	
+		\item arkivera uppförda protokoll och övriga handlingar i därför avsedd pärm
 		\item bistå ordförande i förberedande av sektionsmöten
       \end{attlista}
-      
-      
+
+
     \item[Titulering]
       Alternativ titulering är Sekreterare
 
@@ -1105,8 +1100,8 @@ Vice Skattmästaren hjälper Skattmästaren i dennes arbete.
       \end{attlista}
 
   \end{reglemlista}
-  
-  
+
+
 %%% funktionar %%%
 \funktionar{Vice Studierådsordförande}
  Vice Studierådsordförande hjälper Studierådsordföranden i dennes arbete.
@@ -1119,11 +1114,11 @@ Vice Skattmästaren hjälper Skattmästaren i dennes arbete.
         		\item hjälpa Studierådsorföranden i dennes arbete.
         		\item i Studierådsordförandens frånvaro leda studierådet.
       	\end{attlista}
-      
+
     	\item[Val]
     	Vice Studierådsordförande väljs av Studierådet.
 
- 
+
   \end{reglemlista}
 
 
@@ -1140,8 +1135,8 @@ Vice Skattmästaren hjälper Skattmästaren i dennes arbete.
         		\item med hjälp av alumnigruppen se till att sektionens alumniverksamhet fortskrider
 		\item leda alumnigruppen
 	\end{attlista}
-	
-    
+
+
 \end{reglemlista}
 
 %%% funktionar %%%
@@ -1184,7 +1179,7 @@ Vice Skattmästaren hjälper Skattmästaren i dennes arbete.
         \item föra och underhålla sektionens arkiv
         \item föra och underhålla sektionens dataarkiv
       \end{attlista}
-  
+
   \end{reglemlista}
 
 
@@ -1229,9 +1224,9 @@ Vice Skattmästaren hjälper Skattmästaren i dennes arbete.
          \item ansvara för Case-gruppens ekonomi
          \item sköta kontakten med Näringslivsutskottet
         \end{attlista}
-	
+
 	\end{reglemlista}
-    
+
 %%%funktionar%%%
 \funktionar{Medlem i Case-gruppen}
 	\begin{reglemlista}
@@ -1240,7 +1235,7 @@ Vice Skattmästaren hjälper Skattmästaren i dennes arbete.
         \begin{attlista}
          \item bistå Case-gruppens ledare i dennes arbete
         \end{attlista}
-	
+
 	\end{reglemlista}
 
 %%%funktionar%%%
@@ -1252,17 +1247,17 @@ Vice Skattmästaren hjälper Skattmästaren i dennes arbete.
 \item[Åligganden]
 	Det åligger Sektionslivskvalitetsförhöjaren
     \begin{attlista}
-    \item  se till att kaffe och te finns tillgängligt för sektionens funktionärer 
-    
+    \item  se till att kaffe och te finns tillgängligt för sektionens funktionärer
+
     \item underhålla och rengöra sektionens kaffekokare, samt rengöra sektionen vattenkokare
-    
-    \item sköta microvågsungarna 
-    
+
+    \item sköta microvågsungarna
+
 	\item sköta påfyllning av bordershop
-    
+
  	\item sköta rengörning av borden
     \end{attlista}
-  
+
 \end{reglemlista}
 
 
@@ -1272,13 +1267,13 @@ Vice Skattmästaren hjälper Skattmästaren i dennes arbete.
   D'du-redaktören ger ut D'du.
 
   \begin{reglemlista}
-      
+
   \item[Åligganden]
     Det åligger D'du-redaktören
     \begin{attlista}
       \item ansvara för att D'du trycks och ges ut till sektionens medlemmar i ett nummer per läsvecka.
     \end{attlista}
-    
+
   \end{reglemlista}
 
 %%% funktionar %%%
@@ -1286,7 +1281,7 @@ Vice Skattmästaren hjälper Skattmästaren i dennes arbete.
   DJ ansvarar för att passande musik spelas då sexmästaren så önskar.
 
   \begin{reglemlista}
-      
+
   \item[Åligganden]
     Det åligger DJ:n
     \begin{attlista}
@@ -1312,9 +1307,9 @@ DWWW-ansvarig leder DWWW.
         		\item ansvara för sektionens WWW-sidor
       	\end{attlista}
 
-	
+
 \end{reglemlista}
-  
+
   %%% funktionar %%%
 \funktionar{DWWW-medlem}
   DWWW-medlem hjälper DWWW-ansvarig med arbetet inom DWWW.
@@ -1326,7 +1321,7 @@ DWWW-ansvarig leder DWWW.
       \begin{attlista}
         \item hjälpa DWWW-ansvarig med att underhålla och utveckla sektionens WWW-sidor
       \end{attlista}
-     
+
   \end{reglemlista}
 
 
@@ -1393,7 +1388,7 @@ DWWW-ansvarig leder DWWW.
       \begin{attlista}
         \item i samråd med pubmästaren och barmästaren se till att sexmästeriet har ett tillräckligt vinsortiment till pubar och andra tillställningar exklusive sittningar
         \item hjälpa hovmästaren att tillgodose sektionen med sittningsdryck till sittningar
-       
+
       \end{attlista}
 
   \end{reglemlista}
@@ -1418,33 +1413,33 @@ DWWW-ansvarig leder DWWW.
 
   \end{reglemlista}
 
-  
+
 %%% funktionar %%%
 \funktionar{Jubileumsansvarig}
 	Jubileumsansvarig arrangerar, under Jubileumsgeneralens ledning, Datatekniksektionensjubileum.
-	
+
      \begin{reglemlista}
 	\item[Åligganden]
 		Det åligger Jubileumsansvarig
 		\begin{attlista}
 			\item bistå Jubileumsgeneralens arbete under jubileumet
 		\end{attlista}
-		
+
 	\item[Val]
 		Jubileumsansvarig väljs av Jubileumsgeneralen. Jubileumsansvarig skall stadfästas av styrelsen.
-		
+
 	\item[Entledigande]
 		Jubileumsansvarig må entledigas av Jubileumsgeneralen.
-	
+
      \end{reglemlista}
-	
+
 
 
 
 %%% funktionar %%%
 \funktionar{Jubileumsgeneral}
 	Jubileumsgeneral ansvarar för arrangerandet av Datatekniksektionens jubileum.
-	
+
 	\begin{reglemlista}
 		\item[Åligganden]
 			Det åligger Jubileumsgeneralen
@@ -1453,16 +1448,16 @@ DWWW-ansvarig leder DWWW.
 				\item informera sektionens styrelse om jubileumets fortskridande
 				\item före jubileumets start presentera budgetförslag för sektionens styrelse
 			\end{attlista}
-			
+
 		\item[Val]
 			Jubileumsgeneralen väljs på hösten året innan jubileumet äger rum
-		
-	
-			
+
+
+
 	\end{reglemlista}
-	
-		
-			
+
+
+
 
 %%% funktionar %%%
 \funktionar{Likabehandlingsombud}
@@ -1471,7 +1466,7 @@ DWWW-ansvarig leder DWWW.
 
 	\item[Åligganden]
      	 Det åligger Likabehandlingsombudet
-      
+
 	\begin{attlista}
        		\item bevaka sektionens verksamhet från ett likabehandlingsperspektiv
         		\item uppmärksamma styrelsen på situationer och miljöer som skulle kunna upplevas som kränkande av medlemmar ur sektionen eller bryta mot Teknologkårens likabehandlingspolicy
@@ -1498,7 +1493,7 @@ DWWW-ansvarig leder DWWW.
 tre månader före karnevalen äger rum
         \item hålla kontakten med Karnevalskommittén
       \end{attlista}
-      
+
       \item[Mandatperiod]
       Karnevalsansvariges mandatperiod är 1 juli - 30 juni
 
@@ -1537,10 +1532,10 @@ Kurskommissarien är ansvarig för att det utses kursombud till kurser som läse
 
 	\item[Åligganden]
      	Det åligger Kurskommissarie
-      
+
 	\begin{attlista}
-        		\item förse kursombud med information om hur utvärderingsarbetet av kurser ska gå till 
-		\item informera kursansvariga och se till att de utser kursombud 
+        		\item förse kursombud med information om hur utvärderingsarbetet av kurser ska gå till
+		\item informera kursansvariga och se till att de utser kursombud
 		\item samordna studierådets kursutvärderingsinsatser och se till att studierådet utför det uppdrag som det ålagts av utbildningsnämnden
       	\end{attlista}
 
@@ -1582,7 +1577,7 @@ Köksmästaren är den person som har det övergripande ansvaret för Sexmäster
 		\item vara ansvarig för Sexmästeriets matlagning under deras evenemang
 	\end{attlista}
     \end{reglemlista}
-    
+
 %%% funktionar %%%
 \funktionar{Sektionskock}
     \begin{reglemlista}
@@ -1597,25 +1592,23 @@ Köksmästaren är den person som har det övergripande ansvaret för Sexmäster
 \funktionar{Preferensmästare}
     \begin{reglemlista}
 	\item[Åligganden]
-	Det åligger Sektionskocken
+	Det åligger Preferensmästaren
 	\begin{attlista}
 		\item vara ansvarig för Sexmästeriets matlagning gällande specialkost under deras evenemang
 	\end{attlista}
     \end{reglemlista}
-    
-    
-    
+
 %%% funktionar %%
 \funktionar{Vice köksmästare}
 Vice Köksmästaren hjälper Köksmästaren i dennes arbete.
     \begin{reglemlista}
-    
+
     \item[Åligganden]
-    Det åligger Vice Köksmästaren 
+    Det åligger Vice Köksmästaren
     \begin{attlista}
         \item hjälpa Köksmästaren och att överta Köksmästarens funktion vid dennes frånvaro
     \end{attlista}
-    
+
     \end{reglemlista}
 
 %%% funktionar %%%
@@ -1623,7 +1616,7 @@ Vice Köksmästaren hjälper Köksmästaren i dennes arbete.
   LANparty-ansvarig ansvarar för att anordna LAN-partyn.
 
   \begin{reglemlista}
-      
+
   \item[Åligganden]
     Det åligger LANparty-ansvarig
     \begin{attlista}
@@ -1645,14 +1638,14 @@ Vice Köksmästaren hjälper Köksmästaren i dennes arbete.
         \item närvara på Medaljelelekommitténs möten
         \item lusteligen dela ut medaljer och andra utmärkelser till funktionärer som gjort sig förtjänta därav
       \end{attlista}
-      
+
     \item[Val]
     Medaljelelekommittémedlem väljs av sektionsmötet under VTM
-    
+
     \item[Mandatperiod]
     Mandatperioden för Medaljelelekommittémedlem är 1 juli - 30 juni
-    
-    
+
+
 
   \end{reglemlista}
 
@@ -1665,7 +1658,7 @@ Vice Köksmästaren hjälper Köksmästaren i dennes arbete.
 	\begin{attlista}
 		\item bistå Teknikfokusansvarig i dennes arbete
 	\end{attlista}
-			
+
 	\item[Mandatperiod]
 	Mandatperioden för Medlem i Projektgruppen för Teknikfokus är 1 juli - 30 juni.
 \end{reglemlista}
@@ -1683,7 +1676,7 @@ Vice Köksmästaren hjälper Köksmästaren i dennes arbete.
 
     \item[Mandatperiod]
      Medrepresent Utbildningsnämnd A:s mandatperiod är 1~januari -- 30~juni, respektive 1~juli -- 31~december
-    
+
     \item[Val]
     Medrepresentant Utbildningsnämnd A väljs av Studierådet
 
@@ -1724,12 +1717,12 @@ Nollningsfunktionärer verkar under nollningen för att välkomna de nya student
   \begin{reglemlista}
 
     \item[Åligganden]
-      Det åligger nollningsfuntionärer 
+      Det åligger nollningsfuntionärer
       \begin{attlista}
         \item vara Nollningsutskottet behjälplig under nollningen
         \item välkommna de nya studenterna till Datatekniksektionen
       \end{attlista}
-      
+
       \item[Mandatperiod]
      Nollningsfunktionärens mandatperiod är 1~april -- 30~september
 
@@ -1766,7 +1759,7 @@ Nollningsfunktionärer verkar under nollningen för att välkomna de nya student
       \end{attlista}
 
   \end{reglemlista}
-  
+
   %%% funktionar %%%
 \funktionar{Barmästare}
   Barmästaren ansvarar för barverksamheten under sittningar.
@@ -1781,7 +1774,7 @@ Nollningsfunktionärer verkar under nollningen för att välkomna de nya student
       \end{attlista}
 
   \end{reglemlista}
-  
+
   %%% funktionar %%%
 \funktionar{Vice Barmästare}
   Vice Barmästaren hjälper Barmästaren i dennes arbete.
@@ -1799,7 +1792,7 @@ Nollningsfunktionärer verkar under nollningen för att välkomna de nya student
 
 %%% funktionar %%%
 \funktionar{Readmeredaktös}
-  Readmeredaktösen ger ut sektionstidningen README. 
+  Readmeredaktösen ger ut sektionstidningen README.
 
   \begin{reglemlista}
 
@@ -1837,7 +1830,7 @@ Nollningsfunktionärer verkar under nollningen för att välkomna de nya student
         \item verkställa fortlöpande inventering eller kontrollera ställd inventering av sektionens kassa och övriga tillgångar
         \item tillse huruvida sektionens organisation av och kontroll över bokföring är tillfredsställande
         \item senast tio läsdagar innan vårterminsmötet, året
-efter mandatperioden, till styrelsen inlämna revisionsberättelse. 
+efter mandatperioden, till styrelsen inlämna revisionsberättelse.
       \end{attlista}
 
     \item[Rättigheter]
@@ -1848,7 +1841,7 @@ efter mandatperioden, till styrelsen inlämna revisionsberättelse.
         \item erhålla upplysningar rörande sektionens verksamhet och förvaltning
         \item närvara vid sektionens samtliga möten som ständigt adjungerade
       \end{attlista}
-      
+
       \item[Skyldigheter]
       Revisorerna är skyldiga
       \begin{attlista}
@@ -1856,7 +1849,7 @@ efter mandatperioden, till styrelsen inlämna revisionsberättelse.
       \end{attlista}
 
   \end{reglemlista}
-  
+
   %%% funktionar %%%
 \funktionar{root}
   root leder Rootmästeriet.
@@ -1887,7 +1880,7 @@ efter mandatperioden, till styrelsen inlämna revisionsberättelse.
         \item närvara på HMS-kommitténs möten
         \item verka som Brandskyddssamordnare för Datatekniksektionen
       \end{attlista}
-      
+
       \item[Val]
       	Skyddsombudet väljs av Studierådet.
 
@@ -1897,22 +1890,22 @@ efter mandatperioden, till styrelsen inlämna revisionsberättelse.
 %%% funktionar %%%
 \funktionar{Sparkyansvarig}
 	Sparkyansvarig ansvarar för Sparky.
-	
+
 	\begin{reglemlista}
-	
+
 		\item[Åligganden]
 			Det åligger Sparkyansvarig
 			\begin{attlista}
 				\item underhålla och uppdatera spelmaskinen Sparky
 			\end{attlista}
-	
-	\end{reglemlista}	
+
+	\end{reglemlista}
 %%funktionar %%
 \funktionar{Stekare}
     Stekaren tillagar varor som används i maträtterna som serveras i Café iDét
     \begin{reglemlista}
     \item[Åligganden]
-    Det åligger Stekaren 
+    Det åligger Stekaren
     \begin{attlista}
     \item med lämpligt intervall
     tillaga mat åt Cafémästeriets dagliga verksamhet, så att det alltid finns tillgängligt
@@ -1935,8 +1928,8 @@ efter mandatperioden, till styrelsen inlämna revisionsberättelse.
 
 \item[Val] Överphös Electus sätter ihop en grupp bestående av Överphös Electus samt minst två personer till som skall uppfylla följande krav: minst en gammal stabsmedlem, minst en valberedningsmedlem och en annan valfri person som sedan godkänns av styrelsen.”
  \end{reglemlista}
- 
-  
+
+
   %%% funktionar %%%
 \funktionar{Studentrepresentant, HMS-kommité}
  Studentrepresentanten för fram sektionens och studierådets åsikter gentemot den HMSkommité
@@ -1958,8 +1951,8 @@ blivit vald till av TLTHs fullmäktige
 
       \end{attlista}
   \end{reglemlista}
-  
-  
+
+
   %%% funktionar %%%
 \funktionar{Studentrepresentant, Husstyrelse}
  Studentrepresentanten för fram sektionens och studierådets åsikter gentemot den husstyrelse som studenten sitter i. Studentrepresentanten ska förmedla sektionens åsikter inför,
@@ -1977,8 +1970,8 @@ under och efter dessa möten. Åsikterna som förmedlas ska vara förankrade i s
 
       \end{attlista}
   \end{reglemlista}
-  
-  
+
+
 %%% funktionar %%%
 \funktionar{Studentrepresentant, Institutionsstyrelse}
  Studentrepresentanten för fram sektionens och studierådets åsikter gentemot institutionsstyrelsen som studenten sitter i. Studentrepresentanten ska förmedla sektionens åsikter inför, under och efter dessa möten. Åsikterna som förmedlas ska vara förankrade i studierådet. Studentrepresentanten ansvarar för att informera studierådet om det som tagits upp på institutionsstyrelsemötena.
@@ -1994,7 +1987,7 @@ under och efter dessa möten. Åsikterna som förmedlas ska vara förankrade i s
 
       \end{attlista}
   \end{reglemlista}
-  
+
 %%% funktionar %%%
 \funktionar{Studentrepresentant, Programledning}
 Studentrepresentanten för fram sektionens och studierådets åsikter gentemot den programledning som studenten sitter i. Studentrepresentanten ska förmedla sektionens åsikter inför, under och efter dessa möten. Åsikterna som förmedlas ska vara förankrade i studierådet. Studentrepresentanten ansvarar för att informera studierådet om det som tagits upp på mötet för programledningen
@@ -2023,7 +2016,7 @@ blivit vald till av TLTHs fullmäktige
       \end{attlista}
 
   \end{reglemlista}
-  
+
 %%% funktionar %%%
 \funktionar{Studierådets webbansvarig}
  Studierådets webbansvarig ansvarar för studierådets hemsida.
@@ -2041,7 +2034,7 @@ blivit vald till av TLTHs fullmäktige
  		Studierådets webbansvarig väljs av Studierådet
   \end{reglemlista}
 
-  
+
   %%% funktionar %%%
 \funktionar{Studierådssekreterare}
  Studierådssekreterare för protokoll under studierådetsmöten.
@@ -2052,14 +2045,14 @@ blivit vald till av TLTHs fullmäktige
       Det åligger Studierådssekreteraren
       \begin{attlista}
         \item föra protokoll under studierådsmöten.
-        \item se till att dessa förs upp på D-sektionens hemsida. 
+        \item se till att dessa förs upp på D-sektionens hemsida.
       \end{attlista}
 
     \item[Val]
     	Studierådssekreteraren väljs av Studierådet
- 
+
   \end{reglemlista}
-  
+
     %%% funktionar %%%
 \funktionar{sudo}
   sudo hjälper root i dennes arbete
@@ -2127,11 +2120,11 @@ Sångarstridsförmannen är ansvarig för sektionens deltagande i Sångarstriden
 
 %%% funktionar %%%
 \funktionar{Tandemgeneral}
-Tandemgeneralen ska representera Datatekniksektionen på Tandemstafetten och delta 
-vid dess planering och se till att Datatekniksektionens medlemmar får chansen att delta. 
+Tandemgeneralen ska representera Datatekniksektionen på Tandemstafetten och delta
+vid dess planering och se till att Datatekniksektionens medlemmar får chansen att delta.
 
 \begin{reglemlista}
- 
+
 	\item[Åligganden]
  		Det åligger Tandemgeneralen
  		\begin{attlista}
@@ -2146,7 +2139,7 @@ vid dess planering och se till att Datatekniksektionens medlemmar får chansen a
 Datatekniksektionens årliga arbetsmarknadsmässa Teknikfokus
 
  \begin{reglemlista}
- 
+
  	\item[Åligganden]
  		Det åligger Teknikfokusansvarig
  		\begin{attlista}
@@ -2171,16 +2164,16 @@ Datatekniksektionens årliga arbetsmarknadsmässa Teknikfokus
       \begin{attlista}
         \item sköta sektionens växter
       \end{attlista}
-	
+
   \end{reglemlista}
 
 
 %%% funktionar %%%
 \funktionar{Utedischoansvarig}
 	Utedischoansvarig ansvarar för Datatekniksektionens arrangemang i det årliga utedischot.
-	
+
 	\begin{reglemlista}
-	
+
 		\item[Åligganden]
 			Det åligger Utedischoansvarig
 			\begin{attlista}
@@ -2188,7 +2181,7 @@ Datatekniksektionens årliga arbetsmarknadsmässa Teknikfokus
 				\item senast på det sista ordinarie styrelsemötet innan sommaruppehållet presentera en budget för styrelsen
 			\end{attlista}
 	\end{reglemlista}
-	
+
 
 
 
@@ -2265,8 +2258,8 @@ Datatekniksektionens årliga arbetsmarknadsmässa Teknikfokus
 	\item[Val]
 		Världsmästaren väljs av Studierådet.
   \end{reglemlista}
-  
-  
+
+
   %%% funktionar %%%
 \funktionar{Utbytesansvarig}
   Utbytesansvarig är ansvarig för att se till att information angående 	utbyten sprids i sektionen.
@@ -2278,14 +2271,14 @@ Datatekniksektionens årliga arbetsmarknadsmässa Teknikfokus
       \begin{attlista}
         \item hålla kontakt med programledningen om när utbyten sker att sprida information angående utbyten
       \end{attlista}
-      
+
       \item[Mandatperiod]
       Utbytesansvarigs mandatperiod är 1~juli -- 30~juni.
 
 	\item[Val]
 		Utbytesansvarig väljs av Studierådet.
   \end{reglemlista}
-  
+
   %%% funktionar %%%
 \funktionar{Årskursrepresentant för de tre lägre årskurserna}
  Årskursrepresentanten är den som utvärderar våra kurser och framför sina
@@ -2299,7 +2292,7 @@ kursarers åsikter
         \item agera representant för sina kursare inför kursansvarig och framföra deras åsikter som kursombud
         \item delta på årskursens CEQ-möten
         \item skriva slutkommentarer för kursen
-      \end{attlista}     
+      \end{attlista}
       \item[Mandatperiod]
       Utbytesansvarigs mandatperiod är 1~juli -- 30~juni.
 
@@ -2343,11 +2336,11 @@ kursarers åsikter
       \end{attlista}
 
   \end{reglemlista}
-  
-  
+
+
    %%% funktionar %%%
 \funktionar{Semesterfirare}
- 
+
   \begin{reglemlista}
 
     \item[Åligganden]
@@ -2357,8 +2350,8 @@ kursarers åsikter
       \end{attlista}
 
   \end{reglemlista}
-  
-  %%% funktionar %%% 
+
+  %%% funktionar %%%
 \funktionar{\O verpeppare}
 \O verpepparna agerar Nollningsutskottets högra hand genom att vara med i planering
 och genomförande av nollningsrelaterade evenemang. \O verpepparna ansvarar för att leda Pepparna
@@ -2371,8 +2364,8 @@ och genomförande av nollningsrelaterade evenemang. \O verpepparna ansvarar för
       \end{attlista}
 
   \end{reglemlista}
-  
-    %%% funktionar %%% 
+
+    %%% funktionar %%%
 \funktionar{Peppare}
 Pepparna agerar Nollningsutskottets högra hand genom att vara med i planering
 och genomförande av nollningsrelaterade evenemang.


### PR DESCRIPTION
Ändrar så att det inte åligger sektionskocken att göra preferensmästarens jobb