### PR TITLE
[HTM2 2019] Tog bort medaljelelekommittémedlem från VTM

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -129,7 +129,6 @@
 		\item Jubileumsgeneral (1) (väljes året innan jubileet äger rum)
 		\item Valberedningens ordförande (1)
 		\item Valberedningsrepresentanter från de fyra lägsta årskurserna
-		\item Medaljelelekommittémedlem
 	\end{itemize}
 
 	\item[Höstterminsmöte ett]


### PR DESCRIPTION
Enligt https://www.dsek.se/arkiv/moteshandlingar/data/2019/protokoll_htm2_2019.pdf
Punkt 21, den första att-satsen. Den andra att-satsen verkar redan vara implementerad,
så detta kan nästan ses som en redaktionell ändring.