### PR TITLE
[Redaktionella ändringar] Lade till ändringar som missades efter HTM2 2022

### DIFF
--- a/reglemente.tex
+++ b/reglemente.tex
@@ -280,6 +280,8 @@
 		\item Vice Cafémästare
 		\item Dagsansvarig
 		\item Stekare
+        \item Brunchmästare
+        \item Inventarieansvarig
 		\item Funktionärer
 	\end{itemize}
 
@@ -1737,6 +1739,34 @@ Stekaren tillagar varor som används i maträtterna som serveras i Café iDét.
 
 \end{reglemlista}
 
+%%funktionar %%
+\funktionar{Brunchmästare}
+
+\begin{reglemlista}
+	\item[Åligganden]
+	Det åligger Brunchmästare
+	\begin{attlista}
+		\item planera och genomföra bruncher eller andra evenemang för Cafémästeriets räkning
+        \item planera temaenligt sortiment inför temadagar
+        \item koordinera beredning av bakelser som kan säljas vid passande tillfällen
+	\end{attlista}
+
+\end{reglemlista}
+
+\funktionar{Inventarieansvarig}
+
+\begin{reglemlista}
+	\item[Åligganden]
+	Det åligger Inventarieansvarig
+	\begin{attlista}
+		\item ha övergripande ansvar över sortimentet i cafét
+        \item se till så att inköp av ingredienser och sortiment till cafét sker
+        \item i samråd med mästarna, utskottet och sektionen utveckla caféts sortiment
+        \item ansvara för sektionens läskinventarier
+	\end{attlista}
+
+\end{reglemlista}
+
 %%% funktionar %%%
 \funktionar{Stabsmedlem}
 Stabsmedlem arrangerar, under Øverphøs ledning, nollning.
@@ -2205,5 +2235,6 @@ I denna paragraf får endast tolkningar beträffande reglementet införas.
 \end{reglemlista}
 
 \end{document}
+
 
 


### PR DESCRIPTION
Efter HTM2 2022 missades det att lägga till de nya posterna - Brunchmästare och Inventarieansvarig - under punkt 8, cafémästeriets sammansättning, samt under punkt 20, funktionärer. Detta fixar det.