### PR TITLE
[HTM1 2019] (Bortglömt) Tog bort överflödiga poster från SRD

### DIFF
--- a/reglemente.tex
+++ b/reglemente.tex
@@ -666,9 +666,6 @@ Medaljelelekommittén delar ut medaljer till sektionsfunktionärer. Medaljelelek
 		\item Studierådsordförande
 		\item Vice Studierådsordförande
 		\item Studierådssekreterare
-		\item Kurskommissarie
-		\item Studierådets webbansvarig
-		\item Utbytesansvarig
 		\item Studentrepresentant, Husstyrelse
 		\item Studentrepresentant, Institutionsstyrelse
 		\item Studentrepresentant, Programledning


### PR DESCRIPTION
Under HTM1 2019 röstades det igenom att ta bort vissa av posterna från studierådet. De fanns dock kvar under studierådets sammansättning i reglementet. Nu är de borttagna.